### PR TITLE
#3 - graceful error message if Graphite is timing out

### DIFF
--- a/lib/umpire/exceptions.rb
+++ b/lib/umpire/exceptions.rb
@@ -1,1 +1,2 @@
 class MetricNotFound < Exception ; end
+class MetricServiceRequestFailed < Exception ; end

--- a/lib/umpire/graphite.rb
+++ b/lib/umpire/graphite.rb
@@ -3,10 +3,13 @@ module Umpire
     extend self
 
     def get_values_for_range(graphite_url, metric, range)
-      json = RestClient.get("#{graphite_url}/render/?target=#{metric}&format=json&from=-#{range}s")
-      data = JSON.parse(json)
-
-      data.empty? ? raise(MetricNotFound) : data.first["datapoints"].map { |v, _| v }.compact
+      begin
+        json = RestClient.get("#{graphite_url}/render/?target=#{metric}&format=json&from=-#{range}s")
+        data = JSON.parse(json)
+        data.empty? ? raise(MetricNotFound) : data.first["datapoints"].map { |v, _| v }.compact
+      rescue RestClient::RequestFailed
+        raise MetricServiceRequestFailed
+      end
     end
   end
 end

--- a/lib/umpire/web.rb
+++ b/lib/umpire/web.rb
@@ -60,6 +60,9 @@ module Umpire
         rescue MetricNotFound
           status 404
           JSON.dump({"error" => "metric not found"}) + "\n"
+        rescue MetricServiceRequestFailed
+          status 503
+          JSON.dump({"error" => "connecting to Graphite service failed with error 'request timed out'"}) + "\n"
         end
       end
     end

--- a/spec/umpire/graphite_spec.rb
+++ b/spec/umpire/graphite_spec.rb
@@ -28,5 +28,10 @@ describe Umpire::Graphite do
       stub_request_without_values
       lambda { Umpire::Graphite.get_values_for_range(graphite_url, metric, range) }.should raise_error(MetricNotFound)
     end
+
+    it "should raise an exception if the graphite HTTP request fails for any reason" do
+      stub_request(:get, "#{graphite_url}/render/?format=json&from=-#{range}s&target=#{metric}").to_timeout
+      lambda { Umpire::Graphite.get_values_for_range(graphite_url, metric, range) }.should raise_error(MetricServiceRequestFailed)
+    end
   end
 end


### PR DESCRIPTION
If our request fails to Graphite, return a 503 to the client with a reasonable error message.
