### PR TITLE
add an option to use summarized values from multiple sources

### DIFF
--- a/lib/umpire/librato_metrics.rb
+++ b/lib/umpire/librato_metrics.rb
@@ -2,11 +2,13 @@ module Umpire
   module LibratoMetrics
     extend self
 
-    def get_values_for_range(metric, range)
+    def get_values_for_range(metric, range, sum_sources=false)
+      # value == avg
+      value_key = sum_sources ? "summarized" : "value"
       begin
         start_time = Time.now.to_i - range
         results = client.fetch(metric, :start_time => start_time, :summarize_sources => true)
-        results.has_key?('all') ? results["all"].map { |h| h["value"] } : []
+        results.has_key?('all') ? results["all"].map { |h| h[value_key] } : []
       rescue Librato::Metrics::NotFound
         raise MetricNotFound
       rescue Librato::Metrics::NetworkError

--- a/lib/umpire/web.rb
+++ b/lib/umpire/web.rb
@@ -41,6 +41,7 @@ module Umpire
       max = (params["max"] && params["max"].to_f)
       range = (params["range"] && params["range"].to_i)
       empty_ok = params["empty_ok"]
+      summarize_sources = !!params["summarize_sources"]
       librato = params["backend"] && params["backend"] == "librato"
 
       if !(metric && (min || max) && range)
@@ -49,9 +50,9 @@ module Umpire
       else
         begin 
           points = if librato
-            LibratoMetrics.get_values_for_range(metric, range)
+            LibratoMetrics.get_values_for_range(metric, range, summarize_sources)
           else
-            Graphite.get_values_for_range(Config.graphite_url, metric, range) 
+            Graphite.get_values_for_range(Config.graphite_url, metric, range)
           end
           if points.empty?
             status empty_ok ? 200 : 404

--- a/spec/umpire/librato_metrics_spec.rb
+++ b/spec/umpire/librato_metrics_spec.rb
@@ -23,5 +23,15 @@ describe Umpire::LibratoMetrics do
       client_double.should_receive(:fetch).with('foo', :start_time => Time.now.to_i - 60, :summarize_sources => true) { {} }
       Umpire::LibratoMetrics.get_values_for_range('foo', 60).should eq([])
     end
+
+    it "uses summarized data when asked" do
+      data = { "all" => [
+        {"value" => 1, "summarized" => 10},
+        {"value" => 2, "summarized" => 20},
+        {"value" => 365, "summarized" => 3650}
+      ] }
+      client_double.should_receive(:fetch) { data }
+      Umpire::LibratoMetrics.get_values_for_range('foo', 60, true).should eq([10, 20, 3650])
+    end
   end
 end

--- a/spec/umpire/web_spec.rb
+++ b/spec/umpire/web_spec.rb
@@ -25,7 +25,7 @@ module Umpire
         before(:each) do
           authorize "test", "test"
         end
-        
+
         it "should return a 400 if params are not passed" do
           get "/check"
           last_response.status.should eq(400)
@@ -61,7 +61,7 @@ module Umpire
           get "/check?metric=foo.bar&range=60&min=100"
           last_response.status.should eq(500)
         end
-        
+
         it "should return a 200 if the data is within range" do
           Graphite.stub(:get_values_for_range) { [1] }
           get "/check?metric=foo.bar&range=60&min=1"
@@ -69,8 +69,14 @@ module Umpire
         end
 
         it "should call LibratoMetrics if passed the backend param set to librato" do
-          Umpire::LibratoMetrics.should_receive(:get_values_for_range).with('foo.bar', 60) { [] }
+          Umpire::LibratoMetrics.should_receive(:get_values_for_range).with('foo.bar', 60, false) { [] }
           get "/check?metric=foo.bar&range=60&max=100&backend=librato"
+        end
+
+        it "should call LibratoMetrics with summarized sources enabled if passed the summarize_sources param" do
+          Umpire::LibratoMetrics.should_receive(:get_values_for_range).with('foo.bar', 60, true) { [20] }
+          get "/check?metric=foo.bar&range=60&min=10&backend=librato&summarize_sources=true"
+          last_response.should be_ok
         end
       end
     end


### PR DESCRIPTION
This is Librato specific. I don't particularly love using a new param just for that, but I'm open to better suggestions.

Graphite supports functions (eg.: `sumSeries`), but Librato doesn't. They provide only two aggregation mechanisms: avg and sum.
