### PR TITLE
Adding support for metric patterns

### DIFF
--- a/lib/umpire/graphite.rb
+++ b/lib/umpire/graphite.rb
@@ -8,7 +8,7 @@ module Umpire
       begin
         json = RestClient.get(url(graphite_url, metric, range))
         data = JSON.parse(json)
-        data.empty? ? raise(MetricNotFound) : data.first["datapoints"].map { |v, _| v }.compact
+        data.empty? ? raise(MetricNotFound) : data.flat_map { |metric| metric["datapoints"] }.map(&:first).compact
       rescue RestClient::RequestFailed => e
         raise MetricServiceRequestFailed, e.message
       end


### PR DESCRIPTION
Wildcards like hosts.*.response.time currently only catch the first metric returned by the pattern.

This commit makes sure to include all datapoints in the returned values instead of only the first.

Thanks,
-- Thomas Omans
