### PR TITLE
Adding HTTP basic auth for Graphite

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,16 @@ The default metrics target is Graphite.  If you'd like to check [Librato Metrics
 $ curl -i "$UMPIRE_URL/check?metric=custom.api.production.requests.per-sec&min=40&range=60&backend=librato"
 ```
 
+## HTTP basic auth support (for Graphite only)
+
+If your Graphite server is protected by HTTP basic auth you can provide those
+details by supplying a couple of configuration options.
+
+```bash
+$ heroku config:add -r $DEPLOY BASIC_AUTH_USERNAME=your_username
+$ heroku config:add -r $DEPLOY BASIC_AUTH_PASSWORD=your_password
+```
+
 ## Librato Support
 
 Librato returns multiple values from their API for a given metric. These include: count, min, max, sum, value (aka mean) and a few others. In addition librato allows you to optionally provide a statistical function used to generate an aggregated time series across sources by providing a `group_by` param.

--- a/lib/umpire/config.rb
+++ b/lib/umpire/config.rb
@@ -8,8 +8,14 @@ end
 module Umpire
   module Config
 
+    def self.env(k, raise_if_missing = false)
+      value = ENV[k]
+      raise("missing key #{k}") if value.nil? && raise_if_missing
+      value
+    end
+
     def self.env!(k)
-      ENV[k] || raise("missing key #{k}")
+      env(k, true)
     end
 
     def self.deploy; env!("DEPLOY"); end
@@ -18,6 +24,8 @@ module Umpire
     def self.api_key; env!("API_KEY"); end
     def self.librato_email; env!("LIBRATO_EMAIL"); end
     def self.librato_key; env!("LIBRATO_KEY"); end
+    def self.basic_auth_username; env("BASIC_AUTH_USERNAME"); end
+    def self.basic_auth_password; env("BASIC_AUTH_PASSWORD"); end
 
     def self.app
       ENV["APP"] || "umpire"

--- a/lib/umpire/graphite.rb
+++ b/lib/umpire/graphite.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'base64'
 
 module Umpire
   module Graphite
@@ -6,7 +7,7 @@ module Umpire
 
     def get_values_for_range(graphite_url, metric, range)
       begin
-        json = Excon.get(url(graphite_url, metric, range), :expects => [200]).body
+        json = Excon.get(url(graphite_url, metric, range), :headers => headers, :expects => [200]).body
         data = JSON.parse(json)
         data.empty? ? raise(MetricNotFound) : data.flat_map { |metric| metric["datapoints"] }.map(&:first).compact
       rescue Excon::Errors::Error => e
@@ -16,6 +17,17 @@ module Umpire
 
     def url(graphite_url, metric, range)
       URI.encode(URI.decode("#{graphite_url}/render/?target=#{metric}&format=json&from=-#{range}s"))
+    end
+
+    def headers
+      username = Umpire::Config.basic_auth_username
+      password = Umpire::Config.basic_auth_password
+
+      return {} unless (username && password)
+      auth_string = Base64.strict_encode64("#{username}:#{password}")
+      {
+        'Authorization' => "Basic #{auth_string}"
+      }
     end
   end
 end

--- a/spec/umpire/graphite_spec.rb
+++ b/spec/umpire/graphite_spec.rb
@@ -43,6 +43,19 @@ describe Umpire::Graphite do
     end
   end
 
+  describe "headers" do
+    it 'should return nil when the config values are not set' do
+      Umpire::Graphite.headers.should eq({})
+    end
+
+    it 'should return headers with the config values are set' do
+      ENV['BASIC_AUTH_USERNAME'] = 'test'
+      ENV['BASIC_AUTH_PASSWORD'] = 'test'
+
+      Umpire::Graphite.headers['Authorization'].should_not be_nil
+    end
+  end
+
   describe "url" do
     context "with encodable characters" do
       it "should return a properly url encoded url" do


### PR DESCRIPTION
Our Graphite server is protected by HTTP basic auth, this adds support for basic AUTH support, this PR adds support for it and adding README documentation around it.
