### PR TITLE
Allow more than 2 metrics for sum composite

### DIFF
--- a/lib/umpire/librato_metrics.rb
+++ b/lib/umpire/librato_metrics.rb
@@ -80,7 +80,7 @@ module Umpire
 
     def compose_values_for_range(function, metrics, range, options={})
       raise MetricNotComposite, "too few metrics" if metrics.nil? || metrics.size < 2
-      raise MetricNotComposite, "too many metrics" if metrics.size > 2
+      raise MetricNotComposite, "too many metrics" if metrics.size > 2 && function != "sum"
 
       composite = CompositeMetric.for(function)
       values = metrics.map { |m| get_values_for_range(m, range, options) }

--- a/lib/umpire/librato_metrics.rb
+++ b/lib/umpire/librato_metrics.rb
@@ -79,8 +79,10 @@ module Umpire
     end
 
     def compose_values_for_range(function, metrics, range, options={})
+      metric_limit = function == "sum" ? 4 : 2
+
       raise MetricNotComposite, "too few metrics" if metrics.nil? || metrics.size < 2
-      raise MetricNotComposite, "too many metrics" if metrics.size > 2 && function != "sum"
+      raise MetricNotComposite, "too many metrics" if metrics.size > metric_limit
 
       composite = CompositeMetric.for(function)
       values = metrics.map { |m| get_values_for_range(m, range, options) }

--- a/spec/umpire/librato_metrics_spec.rb
+++ b/spec/umpire/librato_metrics_spec.rb
@@ -78,6 +78,12 @@ describe Umpire::LibratoMetrics do
       end.to raise_error(MetricNotComposite)
     end
 
+    it "composes 4 metrics at most for sum" do
+      expect do
+        Umpire::LibratoMetrics.compose_values_for_range("sum", ["foo", "bar", "baz", "foobar", "foobaz"], 60)
+      end.to raise_error(MetricNotComposite)
+    end
+
     %w'divide multiply'.each do |function|
       it "expects at least two metrics for #{function}" do
         expect do

--- a/spec/umpire/librato_metrics_spec.rb
+++ b/spec/umpire/librato_metrics_spec.rb
@@ -78,19 +78,23 @@ describe Umpire::LibratoMetrics do
       end.to raise_error(MetricNotComposite)
     end
 
-    it "expects at least two metrics" do
-      expect do
-        Umpire::LibratoMetrics.compose_values_for_range("divide", ["foo.bar"], 60)
-      end.to raise_error(MetricNotComposite)
+    %w'divide multiply'.each do |function|
+      it "expects at least two metrics for #{function}" do
+        expect do
+          Umpire::LibratoMetrics.compose_values_for_range(function, ["foo.bar"], 60)
+        end.to raise_error(MetricNotComposite)
+      end
     end
 
     it "supports the sum function" do
       data1 = { "all" => [ {"value" => 1}, {"value" => 10}, {"value" => 30} ] }
       data2 = { "all" => [ {"value" => 2}, {"value" => 20}, {"value" => 40} ] }
+      data3 = { "all" => [ {"value" => 3}, {"value" => 30}, {"value" => 50} ] }
       client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
       client_double.should_receive(:fetch).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
-      Umpire::LibratoMetrics.compose_values_for_range("sum", ["foo", "bar"], 60).
-        should eq([3, 30, 70])
+      client_double.should_receive(:fetch).with('buzz', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data3 }
+      Umpire::LibratoMetrics.compose_values_for_range("sum", ["foo", "bar","buzz"], 60).
+        should eq([6, 60, 120])
     end
 
     it "supports the sum function with empty values" do

--- a/spec/umpire/web_spec.rb
+++ b/spec/umpire/web_spec.rb
@@ -146,8 +146,8 @@ describe Umpire::Web do
 
           it "should accept sum as a compose function" do
             Umpire::LibratoMetrics.should_receive(:compose_values_for_range).
-              with("sum", ["foo.bar", "bar.foo"], 60, {}) { [10] }
-            get "/check?metric=foo.bar,bar.foo&range=60&min=10&backend=librato&compose=sum"
+              with("sum", ["foo.bar", "bar.foo", "foo.baz"], 60, {}) { [10] }
+            get "/check?metric=foo.bar,bar.foo,foo.baz&range=60&min=10&backend=librato&compose=sum"
             last_response.should be_ok
           end
 


### PR DESCRIPTION
I have a case where I want to summarize 4 different metrics and ensure at least X happened in the last N minutes.

This PR removes the restriction of only 2 metrics when the compose function is `sum`.