### PR TITLE
rename source in logs to librato_source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .env
 dump.rdb
-
+.bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM jmervine/herokudev-ruby:1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'yajl-ruby'
 gem 'librato-metrics'
 gem 'sinatra'
 gem 'puma'
-gem 'rack-timeout', git: "https://github.com/freeformz/rack-timeout.git"
+gem 'rack-timeout'
 gem 'rack-ssl'
 gem 'excon'
 gem 'scrolls'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/freeformz/rack-timeout.git
-  revision: 319256e659f23c75f76a815c5852058ada47b8a9
-  specs:
-    rack-timeout (0.1.0beta2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -30,6 +24,7 @@ GEM
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
+    rack-timeout (0.3.2)
     rake (10.1.1)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -60,10 +55,13 @@ DEPENDENCIES
   puma
   rack-ssl
   rack-test
-  rack-timeout!
+  rack-timeout
   rake
   rspec
   scrolls
   sinatra
   webmock
   yajl-ruby
+
+BUNDLED WITH
+   1.11.2

--- a/Readme.md
+++ b/Readme.md
@@ -46,10 +46,10 @@ $ curl -i "$UMPIRE_URL/check?metric=active-connections:count:sum&backend=librato
 
 For more info look [here](http://dev.librato.com/v1/get/metrics/:name)
 
-Pass ```emtpy_ok=true``` to have umpire respond with a 200 if the metrics return with no value within a given range. 
+Pass ```emtpy_ok=true``` to have umpire respond with a 200 if the metrics return with no value within a given range.
 
 ## Aggregation
-The default metric values aggregation method is averaging, but you can change it by adding an 'aggregate' query param. Possible aggregation methods are `avg`, `sum`, `max` and `min`. 
+The default metric values aggregation method is averaging, but you can change it by adding an 'aggregate' query param. Possible aggregation methods are `avg`, `sum`, `max` and `min`.
 
 Following query responds with 200 if the `custom.api.production.requests.per-sec` metric has had a maximum value of less than 400 over the last minute:
 
@@ -57,7 +57,7 @@ Following query responds with 200 if the `custom.api.production.requests.per-sec
 $ curl -i "$UMPIRE_URL/check?metric=custom.api.production.requests.per-sec&max=400&range=60&aggregate=max"
 ```
 
-Following query responds with a 200 if the count of `api.prod.addons.plan-changes.errors` metrics has a maximum value of 10 over the last five minutes.  
+Following query responds with a 200 if the count of `api.prod.addons.plan-changes.errors` metrics has a maximum value of 10 over the last five minutes.
 
 ```bash
 $ curl -i curl -i "$UMPIRE_URL/check?metric=api.prod.addons.plan-changes.errors:count&aggregate=sum&max=10&range=300&backend=librato&empty_ok=true"
@@ -78,6 +78,14 @@ $ export UMPIRE_URL=http://umpire:secret@127.0.0.1:5000
 $ curl -i "$UMPIRE_URL/check?metric=pulse.nginx-requests-per-second&max=400&range=300"
 ```
 
+#### Local Docker
+
+```bash
+$ docker-compose build
+$ docker-compose run --rm web bash
+docker$ bundle install --path .
+docker$ bundle exec rake
+```
 
 ## Platform Deploy
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+web:
+  build: .
+  command: bash
+  working_dir: /app/user
+  volumes:
+    - '.:/app/user'
+  ports:
+    - '5000:5000'
+
+  # prevent heroku/ruby from clobber existing bundled gems
+  # comment this out to use 'docker-compose up'
+  entrypoint: ["bash", "-c"]

--- a/lib/umpire/web.rb
+++ b/lib/umpire/web.rb
@@ -143,7 +143,7 @@ module Umpire
 
       backend = params["backend"] || "graphite"
 
-      Umpire::Log.context(action: "check", metric: params["metric"], backend: backend, source: params["source"]) do
+      Umpire::Log.context(action: "check", metric: params["metric"], backend: backend, librato_source: params["source"]) do
         begin
           points = fetch_points(params)
           if points.empty?


### PR DESCRIPTION
Renaming `source` key in logs to `librato_source` for better indexing and faster searching.

@joshuatobin @reidmix 