### PR TITLE
Add support for handmade composite metrics

### DIFF
--- a/lib/umpire/librato_metrics.rb
+++ b/lib/umpire/librato_metrics.rb
@@ -67,7 +67,11 @@ module Umpire
         Log.log({debug: "librato results"}.merge(results))
       end
 
-      if all = results['all']
+      # This is the response you get if you try to request
+      # a handmade composite metric.
+      if all = results.kind_of?(Array) && results.size > 0 && results[0]['series']
+        all.map { |h| h[from] }
+      elsif all = results['all']
         all.map { |h| h[from] }
       else
         []


### PR DESCRIPTION
Basically the response looks different for the composite case.

I've created a sample app that mirrors umpire here:

```sh
export API_KEY=$(heroku sudo config:get API_KEY -a umpire-composite-test)
export URL=https://u:$API_KEY@umpire-composite-test.herokuapp.com/check

# expected to 200
curl "$URL?backend=librato&metric=metrics-api.response.produce.time.hist.0.95&range=300&max=500000000&min=0&source=com.heroku.metrics-api.%2a&empty_ok=true" -i

# expected to 500
curl "$URL?backend=librato&metric=metrics-api.response.produce.time.hist.0.95&range=300&max=5000000&min=0&source=com.heroku.metrics-api.%2a&empty_ok=true" -i
```
