### PR TITLE
updating gems and fixing things that broke b/c of it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source "https://rubygems.org"
 ruby "2.4.0"
 
 gem 'yajl-ruby'
-gem 'librato-metrics', '~> 1.6.0'
-gem 'sinatra', '~> 1.4.4'
+gem 'librato-metrics'
+gem 'sinatra', '~> 1.4.7'
 gem 'puma'
 gem 'rack-timeout'
 gem 'rack-ssl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.5)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     aggregate (0.2.2)
     coderay (1.1.1)
-    crack (0.4.1)
-      safe_yaml (~> 0.9.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    excon (0.31.0)
+    excon (0.54.0)
     faraday (0.10.1)
       multipart-post (>= 1.2, < 3)
-    librato-metrics (1.6.1)
+    hashdiff (0.3.2)
+    librato-metrics (2.0.2)
       aggregate (~> 0.2.2)
-      faraday (~> 0.7)
-      multi_json
+      faraday
     method_source (0.8.2)
     multi_json (1.12.1)
     multipart-post (2.0.0)
@@ -21,37 +22,44 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    public_suffix (2.0.5)
     puma (3.6.2)
     rack (1.6.5)
     rack-protection (1.5.3)
       rack
     rack-ssl (1.4.1)
       rack
-    rack-test (0.6.2)
+    rack-test (0.6.3)
       rack (>= 1.0)
-    rack-timeout (0.3.2)
-    rake (10.1.1)
-    rollbar (2.13.3)
+    rack-timeout (0.4.2)
+    rake (12.0.0)
+    rollbar (2.14.0)
       multi_json
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.7)
-    rspec-expectations (2.14.4)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.4)
-    safe_yaml (0.9.7)
-    scrolls (0.3.3)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    safe_yaml (1.0.4)
+    scrolls (0.3.8)
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     slop (3.6.0)
     tilt (2.0.5)
-    webmock (1.16.1)
-      addressable (>= 2.2.7)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
       crack (>= 0.3.2)
+      hashdiff
     yajl-ruby (1.3.0)
 
 PLATFORMS
@@ -59,7 +67,7 @@ PLATFORMS
 
 DEPENDENCIES
   excon
-  librato-metrics (~> 1.6.0)
+  librato-metrics
   pry
   puma
   rack-ssl
@@ -69,7 +77,7 @@ DEPENDENCIES
   rollbar
   rspec
   scrolls
-  sinatra (~> 1.4.4)
+  sinatra (~> 1.4.7)
   webmock
   yajl-ruby
 

--- a/lib/umpire/librato_metrics.rb
+++ b/lib/umpire/librato_metrics.rb
@@ -61,7 +61,7 @@ module Umpire
         Log.log(options.merge(range: range, metric: metric))
       end
 
-      results = client.fetch(metric, options)
+      results = client.get_measurements(metric, options)
 
       if Config.debug?
         Log.log({debug: "librato results"}.merge(results))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,15 @@ require "webmock/rspec"
 require "rack/test"
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.order = 'random'
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+  config.mock_with :rspec do |c|
+    c.syntax = :should
+  end
 end
 
 ENV["FORCE_HTTPS"] = "false"

--- a/spec/umpire/instruments_spec.rb
+++ b/spec/umpire/instruments_spec.rb
@@ -38,7 +38,7 @@ describe Umpire::Instruments do
         case data[:name]
         when "excon.error"
           data.keys.sort.should eq([:name, :error_class, :error_message].sort)
-          data[:error_class].should eq("Excon::Errors::InternalServerError")
+          data[:error_class].should eq("Excon::Error::InternalServerError")
           data[:error_message].should match(/InternalServerError/)
         end
         blk.call

--- a/spec/umpire/librato_metrics_spec.rb
+++ b/spec/umpire/librato_metrics_spec.rb
@@ -11,23 +11,23 @@ describe Umpire::LibratoMetrics do
   describe "get_values_for_range" do
 
     it "calls the Librato client as expected" do
-      client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { {"all" => []} }
+      client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { {"all" => []} }
       Umpire::LibratoMetrics.get_values_for_range('foo', 60)
     end
 
     it "returns values as expected" do
       data = { "all" => [ {"value" => 1}, {"value" => 10}, {"value" => 365} ] }
-      client_double.should_receive(:fetch) { data }
+      client_double.should_receive(:get_measurements) { data }
       Umpire::LibratoMetrics.get_values_for_range('foo', 60).should eq([1, 10, 365])
     end
 
     it "handles empty data approprately" do
-      client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { {} }
+      client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { {} }
       Umpire::LibratoMetrics.get_values_for_range('foo', 60).should eq([])
     end
 
     it "handles empty data approprately" do
-      client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { [] }
+      client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { [] }
       Umpire::LibratoMetrics.get_values_for_range('foo', 60).should eq([])
     end
 
@@ -37,7 +37,7 @@ describe Umpire::LibratoMetrics do
         {"value" => 2, "sum_means" => 20},
         {"value" => 365, "sum_means" => 3650}
       ] }
-      client_double.should_receive(:fetch) { data }
+      client_double.should_receive(:get_measurements) { data }
       Umpire::LibratoMetrics.get_values_for_range('foo', 60, {from: :sum_means}).should eq([10, 20, 3650])
     end
 
@@ -48,7 +48,7 @@ describe Umpire::LibratoMetrics do
           {"value" => 2, "sum_means" => 20},
           {"value" => 365, "sum_means" => 3650}
         ] }
-        client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources:false, start_time: Time.now.to_i - 60) { data }
+        client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources:false, start_time: Time.now.to_i - 60) { data }
         Umpire::LibratoMetrics.get_values_for_range('foo:sum_means', 60).should eq([10, 20, 3650])
       end
 
@@ -58,13 +58,13 @@ describe Umpire::LibratoMetrics do
           {"value" => 2, "sum_means" => 20},
           {"value" => 365, "sum_means" => 3650}
         ] }
-        client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources:false, start_time: Time.now.to_i - 60, group_by: 'sum') { data }
+        client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources:false, start_time: Time.now.to_i - 60, group_by: 'sum') { data }
         Umpire::LibratoMetrics.get_values_for_range('foo:sum_means:sum', 60).should eq([10, 20, 3650])
       end
     end
 
     it "uses the source when passed" do
-      client_double.should_receive(:fetch).with('foo', {summarize_sources: true, breakout_sources: false, source: "bar", start_time: Time.now.to_i - 60}) { {} }
+      client_double.should_receive(:get_measurements).with('foo', {summarize_sources: true, breakout_sources: false, source: "bar", start_time: Time.now.to_i - 60}) { {} }
       Umpire::LibratoMetrics.get_values_for_range('foo', 60, {source: 'bar'}).should eq([])
     end
   end
@@ -100,8 +100,8 @@ describe Umpire::LibratoMetrics do
     it "supports the subtract function" do
       data1 = { "all" => [ {"value" => 3}, {"value" => 100}, {"value" => 200} ] }
       data2 = { "all" => [ {"value" => 1}, {"value" => 40}, {"value" => 80} ] }
-      client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
-      client_double.should_receive(:fetch).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
+      client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
+      client_double.should_receive(:get_measurements).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
       Umpire::LibratoMetrics.compose_values_for_range("subtract", ["foo", "bar"], 60).
         should eq([2, 60, 120])
     end
@@ -109,8 +109,8 @@ describe Umpire::LibratoMetrics do
     it "supports the subtract function with empty values" do
       data1 = { "all" => [ {"value" => 1}, {"value" => 10}, {"value" => 30} ] }
       data2 = { "all" => [ ] }
-      client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
-      client_double.should_receive(:fetch).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
+      client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
+      client_double.should_receive(:get_measurements).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
       Umpire::LibratoMetrics.compose_values_for_range("subtract", ["foo", "bar"], 60).
         should eq([1, 10, 30])
     end
@@ -119,9 +119,9 @@ describe Umpire::LibratoMetrics do
       data1 = { "all" => [ {"value" => 1}, {"value" => 10}, {"value" => 30} ] }
       data2 = { "all" => [ {"value" => 2}, {"value" => 20}, {"value" => 40} ] }
       data3 = { "all" => [ {"value" => 3}, {"value" => 30}, {"value" => 50} ] }
-      client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
-      client_double.should_receive(:fetch).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
-      client_double.should_receive(:fetch).with('buzz', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data3 }
+      client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
+      client_double.should_receive(:get_measurements).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
+      client_double.should_receive(:get_measurements).with('buzz', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data3 }
       Umpire::LibratoMetrics.compose_values_for_range("sum", ["foo", "bar","buzz"], 60).
         should eq([6, 60, 120])
     end
@@ -129,8 +129,8 @@ describe Umpire::LibratoMetrics do
     it "supports the sum function with empty values" do
       data1 = { "all" => [ {"value" => 1}, {"value" => 10}, {"value" => 30} ] }
       data2 = { "all" => [ ] }
-      client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
-      client_double.should_receive(:fetch).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
+      client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
+      client_double.should_receive(:get_measurements).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
       Umpire::LibratoMetrics.compose_values_for_range("sum", ["foo", "bar"], 60).
         should eq([1, 10, 30])
     end
@@ -138,8 +138,8 @@ describe Umpire::LibratoMetrics do
     it "supports sum_means sources" do
       data1 = { "all" => [ {"value" => 1, "sum_means" => 3}, {"value" => 10, "sum_means" => 20} ] }
       data2 = { "all" => [ {"value" => 2, "sum_means" => 5}, {"value" => 20, "sum_means" => 30} ] }
-      client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
-      client_double.should_receive(:fetch).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
+      client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
+      client_double.should_receive(:get_measurements).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
       Umpire::LibratoMetrics.compose_values_for_range("sum", ["foo", "bar"], 60, {from: :sum_means}).
         should eq([8, 50])
     end
@@ -147,8 +147,8 @@ describe Umpire::LibratoMetrics do
     it "supports the divide function" do
       data1 = { "all" => [ {"value" => 1}, {"value" => 10}, {"value" => 30} ] }
       data2 = { "all" => [ {"value" => 2}, {"value" => 15}, {"value" => 40} ] }
-      client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
-      client_double.should_receive(:fetch).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
+      client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
+      client_double.should_receive(:get_measurements).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
       Umpire::LibratoMetrics.compose_values_for_range("divide", ["foo", "bar"], 60).
         should eq([0.5, 10.0 / 15, 30.0 / 40])
     end
@@ -157,8 +157,8 @@ describe Umpire::LibratoMetrics do
       it "ignores zero denominators" do
         data1 = { "all" => [ {"value" => 1}, {"value" => 5}, {"value" => 30} ] }
         data2 = { "all" => [ {"value" => 2}, {"value" => 0}, {"value" => 15} ] }
-        client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
-        client_double.should_receive(:fetch).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
+        client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
+        client_double.should_receive(:get_measurements).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
         Umpire::LibratoMetrics.compose_values_for_range("divide", ["foo", "bar"], 60).
           should eq([0.5, 30.0 / 15])
       end
@@ -166,8 +166,8 @@ describe Umpire::LibratoMetrics do
       it "supports ignores extra numerators" do
         data1 = { "all" => [ {"value" => 1}, {"value" => 10}, {"value" => 30} ] }
         data2 = { "all" => [ {"value" => 2}, {"value" => 15} ] }
-        client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
-        client_double.should_receive(:fetch).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
+        client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
+        client_double.should_receive(:get_measurements).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
         Umpire::LibratoMetrics.compose_values_for_range("divide", ["foo", "bar"], 60).
           should eq([0.5, 10.0 / 15])
       end
@@ -175,8 +175,8 @@ describe Umpire::LibratoMetrics do
       it "supports ignores extra denominators" do
         data1 = { "all" => [ {"value" => 1}, {"value" => 10} ] }
         data2 = { "all" => [ {"value" => 2}, {"value" => 15}, {"value" => 30} ] }
-        client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
-        client_double.should_receive(:fetch).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
+        client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
+        client_double.should_receive(:get_measurements).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
         Umpire::LibratoMetrics.compose_values_for_range("divide", ["foo", "bar"], 60).
           should eq([0.5, 10.0 / 15])
       end
@@ -185,8 +185,8 @@ describe Umpire::LibratoMetrics do
     it "supports the multiply function" do
       data1 = { "all" => [ {"value" => 1}, {"value" => 10}, {"value" => 30.2} ] }
       data2 = { "all" => [ {"value" => 2}, {"value" => 15}, {"value" => 40.3} ] }
-      client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
-      client_double.should_receive(:fetch).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
+      client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
+      client_double.should_receive(:get_measurements).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
       Umpire::LibratoMetrics.compose_values_for_range("multiply", ["foo", "bar"], 60).
         should eq([2, 150, 30.2 * 40.3])
     end
@@ -195,8 +195,8 @@ describe Umpire::LibratoMetrics do
       it "ignores extra terms in the first values list" do
         data1 = { "all" => [ {"value" => 1}, {"value" => 10}, {"value" => 30} ] }
         data2 = { "all" => [ {"value" => 2}, {"value" => 15} ] }
-        client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
-        client_double.should_receive(:fetch).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
+        client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
+        client_double.should_receive(:get_measurements).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
         Umpire::LibratoMetrics.compose_values_for_range("multiply", ["foo", "bar"], 60).
           should eq([2, 10.0 * 15])
       end
@@ -204,8 +204,8 @@ describe Umpire::LibratoMetrics do
       it "ignores extra terms in the second values list" do
         data1 = { "all" => [ {"value" => 1}, {"value" => 10} ] }
         data2 = { "all" => [ {"value" => 2}, {"value" => 15}, {"value" => 30} ] }
-        client_double.should_receive(:fetch).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
-        client_double.should_receive(:fetch).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
+        client_double.should_receive(:get_measurements).with('foo', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data1 }
+        client_double.should_receive(:get_measurements).with('bar', summarize_sources: true, breakout_sources: false, start_time: Time.now.to_i - 60) { data2 }
         Umpire::LibratoMetrics.compose_values_for_range("multiply", ["foo", "bar"], 60).
           should eq([2, 10.0 * 15])
       end


### PR DESCRIPTION
Forking off `tobin-ruby-2-3-0` to play around.

@joshuatobin Peep this, I think this will fix everything, but I'm not 100% sure if this will break composite metrics or now. Basically, the `librato-metrics` gem as totally changed and upgrading it won't work without reworking the librato handling. ~~IMHO, we should pull out the graphite stuff while we're at it.~~

J

PS Note that this PR is to be merged in to `tobin-ruby-2-3-0` not `master`.