### PR TITLE
Lock scrolls to 0.3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'puma'
 gem 'rack-timeout'
 gem 'rack-ssl'
 gem 'excon'
-gem 'scrolls', '~> 0.3.3'
+gem 'scrolls', '=0.3.3'
 gem 'rollbar'
 gem 'pry'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
     safe_yaml (0.9.7)
-    scrolls (0.3.9)
+    scrolls (0.3.3)
     sinatra (1.4.4)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -68,7 +68,7 @@ DEPENDENCIES
   rake
   rollbar
   rspec
-  scrolls (~> 0.3.3)
+  scrolls (= 0.3.3)
   sinatra
   webmock
   yajl-ruby


### PR DESCRIPTION
This is the version that was being used prior to the ruby upgrade. With
that upgrade, I bumped scrolls to 0.3.9. I noticed in staging that the
logs were being flooded with deprication warnings. Additionally Scrolls
doesn't support the "-W0" ruby flag for silencing deprication warnings.
Given the volume of these messages, I chose to down-grade Scrolls to the
earlier released version to resolve this for now.